### PR TITLE
Add missing port to rake start

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
 web: npm run build:dev
-api: bundle exec rails s
+api: bundle exec rails s -p 3000


### PR DESCRIPTION
Port 3000 was missing from rake start task, which was necessary (for some reason)