### PR TITLE
Remove async socket jobs to allow after_destroy_commit

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -22,7 +22,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   def broadcast(action, **params)
     return if skip_broadcast?
-    ActionDispatcherJob.perform_later(self, action, params)
+    ActionDispatcherJob.perform_now(self, action, params)
   end
 
   private

--- a/app/models/chatroom_sub.rb
+++ b/app/models/chatroom_sub.rb
@@ -32,7 +32,7 @@ class ChatroomSub < ApplicationRecord
   end
 
   after_create_commit :broadcast_create_sub, :generate_sub_message_create
-  after_destroy :generate_sub_message_destroy, :broadcast_destroy
+  after_destroy_commit :generate_sub_message_destroy, :broadcast_destroy
 
   private
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -80,7 +80,7 @@ class Message < ApplicationRecord
   before_validation :generate_slug, unless: :slug?
   after_create_commit :broadcast_create
   after_update_commit :broadcast_update
-  after_destroy :destroy_replies, :broadcast_destroy
+  after_destroy_commit :destroy_replies, :broadcast_destroy
 
   private
 

--- a/app/models/pin.rb
+++ b/app/models/pin.rb
@@ -27,5 +27,5 @@ class Pin < ApplicationRecord
   private
 
   after_create_commit :broadcast_create
-  after_destroy :broadcast_destroy
+  after_destroy_commit :broadcast_destroy
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -24,5 +24,5 @@ class Reaction < ApplicationRecord
   end
 
   after_create_commit :broadcast_create
-  after_destroy :broadcast_destroy
+  after_destroy_commit :broadcast_destroy
 end

--- a/app/models/user_appearance.rb
+++ b/app/models/user_appearance.rb
@@ -27,7 +27,7 @@ class UserAppearance < ApplicationRecord
   end
 
   after_create_commit :broadcast_dispatch_create
-  after_destroy :broadcast_dispatch_destroy
+  after_destroy_commit :broadcast_dispatch_destroy
 
   private
 


### PR DESCRIPTION
Rails wasn't setup for asynchronous ActiveJobs. (Maybe need to look into Sidekiq to handle?)